### PR TITLE
Expanded interface, snappier code

### DIFF
--- a/Math/KMeans.hs
+++ b/Math/KMeans.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE BangPatterns, ScopedTypeVariables #-}
 
 {- |
 Module      :  Math.KMeans
@@ -11,54 +11,85 @@ An implementation of the k-means clustering algorithm based on the efficient vec
 
 -}
 
-module Math.KMeans (kmeans) where
+module Math.KMeans (kmeans, Point, Cluster(..), computeClusters) where
 
 import qualified Data.Vector.Unboxed as V
+import qualified Data.Vector as G
 import qualified Data.List as L
 import Data.Function (on)
 import Debug.Trace
+import qualified Data.Vector.Mutable as M
+import Control.Monad.ST
+
+-- import Control.Monad
+-- import Test.QuickCheck
 
 --- * K-Means clustering algorithm
 
 type Vec = V.Vector Double
+
+type Point a = (Vec,a)
+
 data Cluster = Cluster {
   cid :: !Int,
   center :: !Vec
-  }
+  } -- deriving (Show,Eq)
 
-distance :: Vec -> Vec -> Double
-distance u v = V.sum $ V.zipWith (\a b -> (a - b)^2) u v
+-- genVec = V.fromList `fmap` vectorOf 3 arbitrary
+-- genPts = (flip zip) [0..] `fmap` replicateM 10 genVec
+-- genClusters = do
+--    cs <- replicateM 5 genVec
+--    return (zipWith Cluster [0.. ] cs)
+--
+-- prop_regroup = forAll genClusters $ \c ->
+--                forAll genPts $ \v ->
+--                  s (regroupPoints c v) == s (regroupPoints' c v)
+--    where
+--     same xs = length (L.nub xs) == length xs
+--     s = map L.sort
 
-partitionPoints :: Int -> [Vec] -> [[Vec]]
-partitionPoints k vs = go vs
+
+{-#INLINE distance#-}
+distance :: Point a -> Vec -> Double
+distance (u,_) v = V.sum $ V.zipWith (\a b -> (a - b)^2) u v
+
+partition :: Int -> [a] -> [[a]]
+partition k vs = go vs
   where go vs = case L.splitAt n vs of
           (vs', []) -> [vs']
           (vs', vss) -> vs' : go vss
         n = (length vs + k - 1) `div` k
-        
+
+{-#INLINE computeClusters#-}
 computeClusters :: [[Vec]] -> [Cluster]
 computeClusters = zipWith Cluster [0..] . map f
   where f (x:xs) = let (n, v) = L.foldl' (\(k, s) v' -> (k+1, V.zipWith (+) s v')) (1, x) xs
                    in V.map (\x -> x / (fromIntegral n)) v
 
-regroupPoints :: [Cluster] -> [Vec] -> [[Vec]]
-regroupPoints clusters points = go points
+{-#INLINE regroupPoints#-}
+regroupPoints :: forall a. [Cluster] -> [Point a] -> [[Point a]]
+regroupPoints clusters points = L.filter (not.null) . G.toList . G.accum (flip (:)) (G.replicate (length clusters) []) . map closest $ points
+ where
+   closest p = (cid (L.minimumBy (compare `on` (distance p . center)) clusters),p)
+
+regroupPoints' :: forall a. [Cluster] -> [Point a] -> [[Point a]]
+regroupPoints' clusters points = go points
   where go points = map (map snd) . L.groupBy ((==) `on` fst) . L.sortBy (compare `on` fst) $ map (\p -> (closest p, p)) points
         closest p = cid $ L.minimumBy (compare `on` (distance p . center)) clusters
-        
-kmeansStep :: [Vec] -> [[Vec]] -> [[Vec]]
-kmeansStep points pgroups = regroupPoints (computeClusters pgroups) points
 
-kmeansAux :: [Vec] -> [[Vec]] -> [[Vec]]
+kmeansStep :: [Point a] -> [[Point a]] -> [[Point a]]
+kmeansStep points pgroups = regroupPoints (computeClusters . map (map fst) $ pgroups) points
+
+kmeansAux :: [Point a] -> [[Point a]] -> [[Point a]]
 kmeansAux points pgroups = let pss = kmeansStep points pgroups in
-  case pss == pgroups of
+  case map (map fst) pss == map (map fst) pgroups of
   True -> pgroups
-  False -> kmeansAux points pss   
+  False -> kmeansAux points pss
 
 -- | Performs the k-means clustering algorithm
 --   using trying to use 'k' clusters on the given list of points
-kmeans :: Int -> [V.Vector Double] -> [[V.Vector Double]]
+kmeans :: Int -> [Point a] -> [[Point a]]
 kmeans k points = kmeansAux points pgroups
-  where pgroups = partitionPoints k points
+  where pgroups = partition k points
 
 

--- a/kmeans-vector.cabal
+++ b/kmeans-vector.cabal
@@ -1,5 +1,5 @@
 Name:                kmeans-vector
-Version:             0.1
+Version:             0.2
 Synopsis:            An implementation of the kmeans clustering algorithm based on the vector package
 Description:         Provides a simple (but efficient) implementation of the k-means clustering algorithm. The goal of this algorithm is to, given a list of n-dimensional points, regroup them in k groups, such that each point gets to be in the group to which it is the closest to (using the 'center' of the group). 
 		     .


### PR DESCRIPTION
A common usecase for K-Means is to cluster data elements by clustering their feature vectors, and  unfortunately, the original kmeans code has no clear way of identifying the elements after the clustering. 

I expanded the interface by making the K-Means cluster `(Vec,a)` pairs, which allows recovering the original data object (image, text etc.) from the clustering result. Moreover, I found that by using few inline pragmas and `Data.Vector.accum`  I could further improve the performance by nearly 50%. Even if you don't want to keep the new interface, these changes could improve the performance of the original version.
